### PR TITLE
Ensure context menu bitmap for shell extension is not leaked

### DIFF
--- a/apps/SimpleExt/SimpleShlExt.cpp
+++ b/apps/SimpleExt/SimpleShlExt.cpp
@@ -23,6 +23,8 @@ CSimpleShlExt::~CSimpleShlExt()
 {
 	if (m_szFiles != NULL)
 		delete [] m_szFiles;
+
+	DeleteObject(m_hMenuBmp);
 }
 
 


### PR DESCRIPTION
I noticed your code was leaking a GDI object for the HBITMAP for the context menu.  Added missing call to DeleteObject.  Please update the version on your share and the version hosted by Giuseppe Pischedda for the x64 version.